### PR TITLE
Make now works on paths with % in

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -11,8 +11,8 @@ ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts
 ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
 ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
 
-C_SRC_DIR = $(CURDIR)
-C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
+C_SRC_DIR = .
+C_SRC_OUTPUT ?= ../priv/$(PROJECT).so
 
 # System type and C compiler/flags.
 


### PR DESCRIPTION
Possibly not good makefile style to have relative paths, but there seems to be no way around the problems that arise when percentage characters appear in path names.
