### PR TITLE
Fixes compilation with libphonenumber >= 8.4.1

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,10 +2,7 @@
 
 CURDIR := $(shell pwd)
 BASEDIR := $(abspath $(CURDIR)/..)
-
 PROJECT = phonenumber_util_nif
-#PROJECT ?= $(notdir $(BASEDIR))
-#PROJECT := $(strip $(PROJECT))
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
 ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
@@ -22,15 +19,12 @@ HOMEBREW  := $(shell { type brew; } 2>/dev/null)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
 	CXXFLAGS ?= -O3 -arch x86_64 -Wall
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -finline-functions -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -g -O3 -finline-functions -Wall -Werror
 endif
 
@@ -39,14 +33,11 @@ ifeq ($(UNAME_SYS), Darwin)
 		HOMEBREW_PREFIX = $(shell brew --prefix)
 		HOMEBREW_CFLAGS = -I$(HOMEBREW_PREFIX)/opt/boost/include -I$(HOMEBREW_PREFIX)/opt/icu4c/include -I$(HOMEBREW_PREFIX)/opt/re2/include -I$(HOMEBREW_PREFIX)/opt/protobuf/include -I$(HOMEBREW_PREFIX)/opt/libphonenumber/include
 		HOMEBREW_LDFLAGS = -L$(HOMEBREW_PREFIX)/opt/boost/lib -L$(HOMEBREW_PREFIX)/opt/icu4c/lib -L$(HOMEBREW_PREFIX)/opt/re2/lib -L$(HOMEBREW_PREFIX)/opt/protobuf/lib -L$(HOMEBREW_PREFIX)/opt/libphonenumber/lib
-		CFLAGS += $(HOMEBREW_CFLAGS)
 		LDFLAGS += $(HOMEBREW_LDFLAGS)
 		CXXFLAGS += $(HOMEBREW_CFLAGS)
 	endif
 endif
 
-
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei  -lstdc++ -lboost_system -lboost_date_time -licui18n -licuuc -lprotobuf -lgeocoding -lphonenumber
@@ -54,36 +45,24 @@ LDFLAGS += -shared
 
 # Verbosity.
 
-c_verbose_0 = @echo " C     " $(?F);
-c_verbose = $(c_verbose_$(V))
-
 cpp_verbose_0 = @echo " CPP   " $(?F);
 cpp_verbose = $(cpp_verbose_$(V))
 
 link_verbose_0 = @echo " LD    " $(@F);
 link_verbose = $(link_verbose_$(V))
 
-SOURCES := $(shell find $(C_SRC_DIR) -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
+SOURCES = phonenumber_util_nif.cpp
 OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
 
-COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
 COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
 
 $(C_SRC_OUTPUT): $(OBJECTS)
 	@mkdir -p $(BASEDIR)/priv/
 	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) $(LDLIBS) -o $(C_SRC_OUTPUT)
 
-%.o: %.c
-	$(COMPILE_C) $(OUTPUT_OPTION) $<
-
-%.o: %.cc
-	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
-
-%.o: %.C
-	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
-
-%.o: %.cpp
-	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+phonenumber_util_nif.o: phonenumber_util_nif.cpp
+	$(COMPILE_CPP) -DLPN_HASLOCALONLY $(OUTPUT_OPTION) phonenumber_util_nif.cpp || \
+	$(COMPILE_CPP) $(OUTPUT_OPTION) phonenumber_util_nif.cpp
 
 clean:
 	@rm -f $(C_SRC_OUTPUT) $(OBJECTS)

--- a/c_src/phonenumber_util_nif.cpp
+++ b/c_src/phonenumber_util_nif.cpp
@@ -27,7 +27,9 @@ struct atoms
 	ERL_NIF_TERM atomUnknown;
 
 	ERL_NIF_TERM atomIsPossible;
+  ERL_NIF_TERM atomIsPossibleLocalOnly;
 	ERL_NIF_TERM atomInvalidContryCode;
+  ERL_NIF_TERM atomInvalidLength;
 	ERL_NIF_TERM atomTooShort;
 	ERL_NIF_TERM atomTooLong;
 
@@ -80,7 +82,9 @@ int on_nif_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 	ATOMS.atomUnknown = make_atom(env, "unknown");
 
 	ATOMS.atomIsPossible = make_atom(env, "is_possible");
+  ATOMS.atomIsPossibleLocalOnly = make_atom(env, "is_possible_local_only");
 	ATOMS.atomInvalidContryCode = make_atom(env, "invalid_country_code");
+  ATOMS.atomInvalidLength = make_atom(env, "invalid_length");
 	ATOMS.atomTooShort = make_atom(env, "too_short");
 	ATOMS.atomTooLong = make_atom(env, "too_long");
 
@@ -243,6 +247,10 @@ static ERL_NIF_TERM phonenumber_validation_result_to_term(PhoneNumberUtil::Valid
         	return ATOMS.atomTooShort;
         case PhoneNumberUtil::TOO_LONG:
         	return ATOMS.atomTooLong;
+        case PhoneNumberUtil::IS_POSSIBLE_LOCAL_ONLY:
+          return ATOMS.atomIsPossibleLocalOnly;
+        case PhoneNumberUtil::INVALID_LENGTH:
+          return ATOMS.atomInvalidLength;
     }
 
     return ATOMS.atomInvalidContryCode;

--- a/c_src/phonenumber_util_nif.cpp
+++ b/c_src/phonenumber_util_nif.cpp
@@ -247,10 +247,12 @@ static ERL_NIF_TERM phonenumber_validation_result_to_term(PhoneNumberUtil::Valid
         	return ATOMS.atomTooShort;
         case PhoneNumberUtil::TOO_LONG:
         	return ATOMS.atomTooLong;
+       #ifdef LPN_HASLOCALONLY
         case PhoneNumberUtil::IS_POSSIBLE_LOCAL_ONLY:
           return ATOMS.atomIsPossibleLocalOnly;
         case PhoneNumberUtil::INVALID_LENGTH:
           return ATOMS.atomInvalidLength;
+       #endif
     }
 
     return ATOMS.atomInvalidContryCode;

--- a/test/phonenumber_util_test.erl
+++ b/test/phonenumber_util_test.erl
@@ -44,7 +44,7 @@ normalize_digits_only_test() ->
     <<"03456234">> = phonenumber_util:normalize_digits_only(<<"034-56&+a#234">>).
 
 normalize_diallable_chars_only_test() ->
-    <<"03*456+234">> = phonenumber_util:normalize_diallable_chars_only(<<"03*4-56&+a#234">>).
+    <<"03*456+#234">> = phonenumber_util:normalize_diallable_chars_only(<<"03*4-56&+a#234">>).
 
 get_national_significant_number_test() ->
     P1 = phonenumber:new(),

--- a/test/phonenumber_util_test.erl
+++ b/test/phonenumber_util_test.erl
@@ -397,22 +397,22 @@ is_possible_number_with_reason_test() ->
     P1 = phonenumber:new(),
     P11 = phonenumber:set_country_code(1, P1),
     P12 = phonenumber:set_national_number(6502530000, P11),
-    is_possible = phonenumber_util:is_possible_number_with_reason(P12), 
+    is_possible = phonenumber_util:is_possible_number_with_reason(P12),
 
     P2 = phonenumber:new(),
     P21 = phonenumber:set_country_code(1, P2),
     P22 = phonenumber:set_national_number(2530000, P21),
-    is_possible = phonenumber_util:is_possible_number_with_reason(P22),  
+    is_possible_local_only = phonenumber_util:is_possible_number_with_reason(P22),
 
     P3 = phonenumber:new(),
     P31 = phonenumber:set_country_code(0, P3),
     P32 = phonenumber:set_national_number(2530000, P31),
-    invalid_country_code = phonenumber_util:is_possible_number_with_reason(P32), 
+    invalid_country_code = phonenumber_util:is_possible_number_with_reason(P32),
 
     P4 = phonenumber:new(),
     P41 = phonenumber:set_country_code(1, P4),
     P42 = phonenumber:set_national_number(253000, P41),
-    too_short = phonenumber_util:is_possible_number_with_reason(P42), 
+    too_short = phonenumber_util:is_possible_number_with_reason(P42),
 
     P5 = phonenumber:new(),
     P51 = phonenumber:set_country_code(1, P5),


### PR DESCRIPTION
:warning: compilation will fail with older versions

I'm using elibphonenumber for an Elixir app in production, and I use Archlinux as a dev environment. Due to it's rolling release nature, libphonenumber 8.5.0 is already available.

There were two breaking changes to compilation that I could find:
- the addition of two new return codes for ValidationResult, which I added as corresponding atoms
- dash (#) is now considered a diallable character, which only broke a test case, but not compilation

I reviewed release_notes of libphonenumber and didn't find anything else that was relevant.

Thanks for reviewing the PR :)
