### PR TITLE
Exclude .so from hex package

### DIFF
--- a/src/elibphonenumber.app.src
+++ b/src/elibphonenumber.app.src
@@ -11,5 +11,6 @@
     kernel,
     stdlib
   ]},
-  {env, []}
+  {env, []},
+  {exclude_files, ["priv/phonenumber_util_nif.so"]}
 ]}.


### PR DESCRIPTION
I'm not sure this works, as I couldn't test it, but according to https://github.com/hexpm/rebar3_hex/pull/40 the exclude_files option in app.src works as expected.

This should fix #10 