### PR TITLE
Prefix uses of set and list with std:: (libphonenumber 8.7.0 compatibility)

### DIFF
--- a/c_src/phonenumber_util_nif.cpp
+++ b/c_src/phonenumber_util_nif.cpp
@@ -465,7 +465,7 @@ static ERL_NIF_TERM GetSupportedRegions_nif(ErlNifEnv* env, int argc, const ERL_
 {
     PhoneNumberUtil *phone_util_ = PhoneNumberUtil::GetInstance();
 
-    set<string> regions;
+    std::set<string> regions;
     phone_util_->GetSupportedRegions(&regions);
     unsigned int cnt = regions.size();
     ERL_NIF_TERM arr[cnt];
@@ -474,7 +474,7 @@ static ERL_NIF_TERM GetSupportedRegions_nif(ErlNifEnv* env, int argc, const ERL_
     ERL_NIF_TERM ret;
     unsigned char *region;
 
-    for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
+    for (std::set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
     {
         region = enif_make_new_binary(env, it->size(), &ret);
         std::copy(it->begin(), it->end(), region);
@@ -870,7 +870,7 @@ static ERL_NIF_TERM GetRegionCodesForCountryCallingCode_nif(ErlNifEnv* env, int 
 
     PhoneNumberUtil *phone_util_ = PhoneNumberUtil::GetInstance();
 
-    list<string> regions;
+    std::list<string> regions;
 
     phone_util_->GetRegionCodesForCountryCallingCode(code, &regions);
     unsigned int cnt = regions.size();
@@ -880,7 +880,7 @@ static ERL_NIF_TERM GetRegionCodesForCountryCallingCode_nif(ErlNifEnv* env, int 
     ERL_NIF_TERM ret;
     unsigned char *region;
 
-    for (list<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
+    for (std::list<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
     {
         region = enif_make_new_binary(env, it->size(), &ret);
         std::copy(it->begin(), it->end(), region);


### PR DESCRIPTION
Hello again John,

### The issue

Going from libphonenumber version 8.6.0 to 8.7.0 causes compilation to error with the following output:

    $ rebar3 compile
    ===> Verifying dependencies...
    ===> Compiling elibphonenumber
    c++ -O3 -arch x86_64 -Wall -I/usr/local/opt/boost/include -I/usr/local/opt/icu4c/include -I/usr/local/opt/re2/include -I/usr/local/opt/protobuf/include -I/usr/local/opt/libphonenumber/include -fPIC -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/erts-9.1/include/ -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/lib/erl_interface-3.10/include  -c -DLPN_HASLOCALONLY -o phonenumber_util_nif.o phonenumber_util_nif.cpp || \
        c++ -O3 -arch x86_64 -Wall -I/usr/local/opt/boost/include -I/usr/local/opt/icu4c/include -I/usr/local/opt/re2/include -I/usr/local/opt/protobuf/include -I/usr/local/opt/libphonenumber/include -fPIC -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/erts-9.1/include/ -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/lib/erl_interface-3.10/include  -c -o phonenumber_util_nif.o phonenumber_util_nif.cpp
    phonenumber_util_nif.cpp:263:12: warning: enumeration value 'PhoneNumber_CountryCodeSource_UNSPECIFIED' not handled in switch [-Wswitch]
        switch(country_code_source)
            ^
    phonenumber_util_nif.cpp:263:12: note: add missing switch cases
        switch(country_code_source)
            ^
    phonenumber_util_nif.cpp:468:5: error: no template named 'set'; did you mean 'std::set'?
        set<string> regions;
        ^~~
        std::set
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/set:400:28: note: 'std::set' declared here
    class _LIBCPP_TEMPLATE_VIS set
                            ^
    phonenumber_util_nif.cpp:477:14: error: unexpected type name 'string': expected expression
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                ^
    phonenumber_util_nif.cpp:477:10: error: use of undeclared identifier 'set'; did you mean 'ret'?
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
            ^~~
            ret
    phonenumber_util_nif.cpp:474:18: note: 'ret' declared here
        ERL_NIF_TERM ret;
                    ^
    phonenumber_util_nif.cpp:477:23: error: no member named 'iterator' in the global namespace
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                        ~~^
    phonenumber_util_nif.cpp:477:52: error: use of undeclared identifier 'it'
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                                                    ^
    phonenumber_util_nif.cpp:477:73: error: use of undeclared identifier 'it'
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                                                                            ^
    phonenumber_util_nif.cpp:479:44: error: use of undeclared identifier 'it'
            region = enif_make_new_binary(env, it->size(), &ret);
                                            ^
    phonenumber_util_nif.cpp:480:19: error: use of undeclared identifier 'it'
            std::copy(it->begin(), it->end(), region);
                    ^
    phonenumber_util_nif.cpp:480:32: error: use of undeclared identifier 'it'
            std::copy(it->begin(), it->end(), region);
                                ^
    phonenumber_util_nif.cpp:873:5: error: no template named 'list'; did you mean 'std::list'?
        list<string> regions;
        ^~~~
        std::list
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/list:803:28: note: 'std::list' declared here
    class _LIBCPP_TEMPLATE_VIS list
                            ^
    phonenumber_util_nif.cpp:883:10: error: no template named 'list'; did you mean 'std::list'?
        for (list<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
            ^~~~
            std::list
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/list:803:28: note: 'std::list' declared here
    class _LIBCPP_TEMPLATE_VIS list
                            ^
    1 warning and 11 errors generated.
    phonenumber_util_nif.cpp:240:12: warning: enumeration values 'IS_POSSIBLE_LOCAL_ONLY' and 'INVALID_LENGTH' not handled in switch [-Wswitch]
        switch(validation_result)
            ^
    phonenumber_util_nif.cpp:240:12: note: add missing switch cases
        switch(validation_result)
            ^
    phonenumber_util_nif.cpp:263:12: warning: enumeration value 'PhoneNumber_CountryCodeSource_UNSPECIFIED' not handled in switch [-Wswitch]
        switch(country_code_source)
            ^
    phonenumber_util_nif.cpp:263:12: note: add missing switch cases
        switch(country_code_source)
            ^
    phonenumber_util_nif.cpp:468:5: error: no template named 'set'; did you mean 'std::set'?
        set<string> regions;
        ^~~
        std::set
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/set:400:28: note: 'std::set' declared here
    class _LIBCPP_TEMPLATE_VIS set
                            ^
    phonenumber_util_nif.cpp:477:14: error: unexpected type name 'string': expected expression
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                ^
    phonenumber_util_nif.cpp:477:10: error: use of undeclared identifier 'set'; did you mean 'ret'?
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
            ^~~
            ret
    phonenumber_util_nif.cpp:474:18: note: 'ret' declared here
        ERL_NIF_TERM ret;
                    ^
    phonenumber_util_nif.cpp:477:23: error: no member named 'iterator' in the global namespace
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                        ~~^
    phonenumber_util_nif.cpp:477:52: error: use of undeclared identifier 'it'
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                                                    ^
    phonenumber_util_nif.cpp:477:73: error: use of undeclared identifier 'it'
        for (set<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
                                                                            ^
    phonenumber_util_nif.cpp:479:44: error: use of undeclared identifier 'it'
            region = enif_make_new_binary(env, it->size(), &ret);
                                            ^
    phonenumber_util_nif.cpp:480:19: error: use of undeclared identifier 'it'
            std::copy(it->begin(), it->end(), region);
                    ^
    phonenumber_util_nif.cpp:480:32: error: use of undeclared identifier 'it'
            std::copy(it->begin(), it->end(), region);
                                ^
    phonenumber_util_nif.cpp:873:5: error: no template named 'list'; did you mean 'std::list'?
        list<string> regions;
        ^~~~
        std::list
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/list:803:28: note: 'std::list' declared here
    class _LIBCPP_TEMPLATE_VIS list
                            ^
    phonenumber_util_nif.cpp:883:10: error: no template named 'list'; did you mean 'std::list'?
        for (list<string>::iterator it=regions.begin(); it!=regions.end(); ++it, i++)
            ^~~~
            std::list
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/list:803:28: note: 'std::list' declared here
    class _LIBCPP_TEMPLATE_VIS list
                            ^
    2 warnings and 11 errors generated.
    make: *** [phonenumber_util_nif.o] Error 1
    ===> Hook for compile failed!

This stems from attempts to use `set` and `list` without prefixing them with `std::`. This issue has surfaced because in libphonenumber 8.7.0 they no longer `using std::list;` and `using std::set;` in the `i18n::phonenumbers` namespace.

8.6.0 https://github.com/googlei18n/libphonenumber/blob/v8.6.0/cpp/src/phonenumbers/phonenumberutil.h#L41
8.7.0 https://github.com/googlei18n/libphonenumber/blob/v8.7.0/cpp/src/phonenumbers/phonenumberutil.h#L38

### The fix

Prefix uses of `set` and `list` with `std::`. This causes compilation to complete without error like so:

    $ rebar3 compile
    ===> Verifying dependencies...
    ===> Compiling elibphonenumber
    c++ -O3 -arch x86_64 -Wall -I/usr/local/opt/boost/include -I/usr/local/opt/icu4c/include -I/usr/local/opt/re2/include -I/usr/local/opt/protobuf/include -I/usr/local/opt/libphonenumber/include -fPIC -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/erts-9.1/include/ -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/lib/erl_interface-3.10/include  -c -DLPN_HASLOCALONLY -o phonenumber_util_nif.o phonenumber_util_nif.cpp || \
        c++ -O3 -arch x86_64 -Wall -I/usr/local/opt/boost/include -I/usr/local/opt/icu4c/include -I/usr/local/opt/re2/include -I/usr/local/opt/protobuf/include -I/usr/local/opt/libphonenumber/include -fPIC -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/erts-9.1/include/ -I /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/lib/erl_interface-3.10/include  -c -o phonenumber_util_nif.o phonenumber_util_nif.cpp
    phonenumber_util_nif.cpp:263:12: warning: enumeration value 'PhoneNumber_CountryCodeSource_UNSPECIFIED' not handled in switch [-Wswitch]
        switch(country_code_source)
            ^
    phonenumber_util_nif.cpp:263:12: note: add missing switch cases
        switch(country_code_source)
            ^
    1 warning generated.
    cc phonenumber_util_nif.o -arch x86_64 -flat_namespace -undefined suppress -L/usr/local/opt/boost/lib -L/usr/local/opt/icu4c/lib -L/usr/local/opt/re2/lib -L/usr/local/opt/protobuf/lib -L/usr/local/opt/libphonenumber/lib -shared -L /Users/daniel/.asdf/installs/erlang/20.1/lib/erlang/lib/erl_interface-3.10/lib -lerl_interface -lei  -lstdc++ -lboost_system -lboost_date_time -licui18n -licuuc -lprotobuf -lgeocoding -lphonenumber -o ../priv/phonenumber_util_nif.so